### PR TITLE
2.7 compatibility for OrderedDictionary

### DIFF
--- a/recipes/Python/107747_Ordered_Dictionary/recipe-107747.py
+++ b/recipes/Python/107747_Ordered_Dictionary/recipe-107747.py
@@ -51,3 +51,7 @@ class odict(UserDict):
 
     def values(self):
         return map(self.get, self._keys)
+
+    def move_to_end(self, key):
+        self._keys.remove(key)
+        self._keys.append(key)

--- a/recipes/Python/107747_Ordered_Dictionary/recipe-107747.py
+++ b/recipes/Python/107747_Ordered_Dictionary/recipe-107747.py
@@ -45,8 +45,9 @@ class odict(UserDict):
 
     def update(self, dict):
         UserDict.update(self, dict)
-        for key in dict.keys():
-            if key not in self._keys: self._keys.append(key)
+        for key in dict.__iter__():
+            if key not in self._keys: 
+                self._keys.append(key)
 
     def values(self):
         return map(self.get, self._keys)


### PR DESCRIPTION
dict doesn't have keys() in older versions