### PR TITLE
Fix an issue with rlcompleter not visible from the complete function.

### DIFF
--- a/recipes/Python/498182_sane_tab_completion_in_pdb/recipe-498182.py
+++ b/recipes/Python/498182_sane_tab_completion_in_pdb/recipe-498182.py
@@ -22,6 +22,7 @@ def complete(self, text, state):
     """
     # keep a completer class, and make sure that it uses the current local scope 
     if not hasattr(self, 'completer'):
+        import rlcompleter
         self.completer = rlcompleter.Completer(self.curframe.f_locals)
     else:
         self.completer.namespace = self.curframe.f_locals


### PR DESCRIPTION
Explicitly import rlcompleter as it may not be visible when imported in .pdbrc.
The issue was observed on Python 2.7.13.