### PR TITLE
Fix reduce

### DIFF
--- a/recipes/Python/577879_Create_nested_dictionary/recipe-577879.py
+++ b/recipes/Python/577879_Create_nested_dictionary/recipe-577879.py
@@ -1,4 +1,6 @@
 import os
+from functools import reduce
+
 
 def get_directory_structure(rootdir):
     """


### PR DESCRIPTION
In Python 3, reduce is nolonger part of the builtin functions and has
instead been moved to functools hence breaking this code.
I added in a line of code so this works again in Python 3