### PR TITLE
Fix bug in intersection

### DIFF
--- a/recipes/Python/576816_Interval/recipe-576816.py
+++ b/recipes/Python/576816_Interval/recipe-576816.py
@@ -50,7 +50,7 @@ class Interval(object):
             other, self = self, other
         if self.end <= other.start:
             return Interval(self.start, self.start)
-        return Interval(other.start, self.end)
+        return Interval(other.start, min(self.end, other.end))
 
 
     def hull(self, other):


### PR DESCRIPTION
Without this fix, there is an error when one interval is contained in the other.
```
    Interval(4, 7).intersection(Interval(5, 6))
```
returns 
```
    Interval(5, 7)
```
But it should return
```
    Interval(5, 6)
```