### PR TITLE
Fix proper_subset when other shares boundary

### DIFF
--- a/recipes/Python/576816_Interval/recipe-576816.py
+++ b/recipes/Python/576816_Interval/recipe-576816.py
@@ -84,7 +84,8 @@ class Interval(object):
 
     def proper_subset(self, other):
         "@return: True iff self is proper subset of other."
-        return self.start > other.start and self.end < other.end
+        return ((self.start > other.start and self.end <= other.end) or
+                (self.start >= other.start and self.end < other.end))
          
 
     def empty(self):


### PR DESCRIPTION
Without this fix, proper_subset gives the wrong answer both intervals share one boundary

    Interval(4, 6).proper_subset(Interval(4, 7))

should return True, but without this fix, it returns False