### PR TITLE
Update recipe-84516.py to fix CDATA bug.

### DIFF
--- a/recipes/Python/84516_Using_SAX2_LexicalHandler/recipe-84516.py
+++ b/recipes/Python/84516_Using_SAX2_LexicalHandler/recipe-84516.py
@@ -44,6 +44,7 @@ class EchoGenerator(saxutils.XMLGenerator):
         self._in_entity = 0
 
     def startCDATA(self):
+        self._finish_pending_start_element()
         self._out.write('<![CDATA[')
         self._in_cdata = 1
 


### PR DESCRIPTION
Fixes a bug which would render `<tag><![CDATA[MDAyNz]]></tag>` as `<tag <![CDATA[MDAyNz]]> />`